### PR TITLE
Do not crash on bootstrapping as hazelcast node might not be ready at that time.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,17 @@ services:
     build: .
     ports:
       - "5678:8080"
-    links:
-      - hazelcast
     environment:
       - HC_ADDRS=hazelcast:5701
       - LISTEN_ADDR=127.0.0.1:8080
     working_dir: /code
+    networks:
+      - integrationtest
 
   hazelcast:
     image: hazelcast/hazelcast:3.7.6
+    networks:
+      - integrationtest
 
-
+networks:
+  integrationtest: {}


### PR DESCRIPTION
1. Make the 'createClient()' asynchronous.
2. In the 'reconnect' scenario, initiate reconnect synchronously and wait for the result.